### PR TITLE
Represent Structs and Enums as memory addresses, not aggregate values

### DIFF
--- a/a.k1
+++ b/a.k1
@@ -1,8 +1,0 @@
-fn main(): int {
-  let asdf = "asdf";
-  let locn: compiler/SourceLocation = {
-    filename: asdf,
-    line: 100,
-  };
-  crash(context locn)("uhoh")
-}

--- a/a.k1
+++ b/a.k1
@@ -1,0 +1,8 @@
+fn main(): int {
+  let asdf = "asdf";
+  let locn: compiler/SourceLocation = {
+    filename: asdf,
+    line: 100,
+  };
+  crash(context locn)("uhoh")
+}

--- a/agg.c
+++ b/agg.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+struct P3 { long x; long y; long z; };
+
+long one(struct P3 p) {
+  return p.x;
+}
+
+int main() {
+  struct P3 p;
+  p.x = 3;
+  p.y = 4;
+  p.z = 0;
+  return (int)one(p);
+}

--- a/agg.c
+++ b/agg.c
@@ -6,10 +6,19 @@ long one(struct P3 p) {
   return p.x;
 }
 
+struct P3 structRet() {
+  struct P3 p;
+  p.x = 1;
+  p.y = 2;
+  p.z = 3;
+  return p;
+}
+
 int main() {
   struct P3 p;
   p.x = 3;
   p.y = 4;
   p.z = 0;
-  return (int)one(p);
+  struct P3 p3 = structRet();
+  return (int)p3.z;
 }

--- a/agg.k1
+++ b/agg.k1
@@ -42,10 +42,15 @@ fn two(p: P3*): int {
   p.z
 }
 
+fn retStruct(): P3 {
+  { x: 1, y: 2, z: 3 }
+}
+
 fn main(): int {
   // Test with agg, no agg, referencing, no referencing
   let* p1 = { x: 1, y: 2, z: 3 };
   let o = one(p1.*);
   let t = two(p1);
-  t
+  let p3 = retStruct();
+  p3.y
 }

--- a/agg.k1
+++ b/agg.k1
@@ -1,0 +1,51 @@
+// Functions later
+// fn getX(p: { x: int, y: int}): int { p.x }
+
+// starting point
+// ; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone willreturn
+// define i64 @getX({ i64, i64 } %p) #0 {
+// entry:
+//   %p.fca.0.extract = extractvalue { i64, i64 } %p, 0
+//   %p.fca.1.extract = extractvalue { i64, i64 } %p, 1
+//   %loaded_value.fca.0.insert = insertvalue { i64, i64 } poison, i64 %p.fca.0.extract, 0
+//   %loaded_value.fca.1.insert = insertvalue { i64, i64 } %loaded_value.fca.0.insert, i64 %p.fca.1.extract, 1
+//   %struc.x = extractvalue { i64, i64 } %loaded_value.fca.1.insert, 0
+//   ret i64 %struc.x
+// }
+// Goal:
+// %x = getelementptr %p, 0, 1
+// ret i64 %x
+
+// Starting point
+// define i64 @main() {
+// entry:
+//   %p = alloca { i64, i64 }, align 8
+//   store { i64, i64 } { i64 3, i64 4 }, ptr %p, align 8
+//   %0 = load { { i64, ptr } }, ptr @str, align 8
+//   %struct_init_0 = insertvalue { { { i64, ptr } }, i64 } undef, { { i64, ptr } } %0, 0
+//   %struct_init_1 = insertvalue { { { i64, ptr } }, i64 } %struct_init_0, i64 33, 1
+//   %loaded_value = load { i64, i64 }, ptr %p, align 8
+//   %struc.x = extractvalue { i64, i64 } %loaded_value, 0
+//   %"==_i1" = icmp eq i64 %struc.x, 3
+//   %"==_res" = sext i1 %"==_i1" to i8
+//   %1 = call i8 @assert({ { { i64, ptr } }, i64 } %struct_init_1, i8 %"==_res")
+//   ret i64 0
+// }
+
+deftype alias P3 = { x: int, y: int, z: int }
+fn one(p: P3): int {
+  // if p.z == 3 println("YES");
+  p.z
+}
+fn two(p: P3*): int {
+  //if p.z == 3 println("YES");
+  p.z
+}
+
+fn main(): int {
+  // Test with agg, no agg, referencing, no referencing
+  let* p1 = { x: 1, y: 2, z: 3 };
+  let o = one(p1.*);
+  let t = two(p1);
+  t
+}

--- a/agg_c.ll
+++ b/agg_c.ll
@@ -15,6 +15,17 @@ define i64 @one(ptr noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
+define void @structRet(ptr noalias sret(%struct.P3) align 8 %0) #0 {
+  %2 = getelementptr inbounds %struct.P3, ptr %0, i32 0, i32 0
+  store i64 1, ptr %2, align 8
+  %3 = getelementptr inbounds %struct.P3, ptr %0, i32 0, i32 1
+  store i64 2, ptr %3, align 8
+  %4 = getelementptr inbounds %struct.P3, ptr %0, i32 0, i32 2
+  store i64 3, ptr %4, align 8
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
 define i32 @main() #0 {
   %1 = alloca i32, align 4
   %2 = alloca %struct.P3, align 8
@@ -26,17 +37,14 @@ define i32 @main() #0 {
   store i64 4, ptr %5, align 8
   %6 = getelementptr inbounds %struct.P3, ptr %2, i32 0, i32 2
   store i64 0, ptr %6, align 8
-  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %3, ptr align 8 %2, i64 24, i1 false)
-  %7 = call i64 @one(ptr noundef %3)
-  %8 = trunc i64 %7 to i32
-  ret i32 %8
+  call void @structRet(ptr sret(%struct.P3) align 8 %3)
+  %7 = getelementptr inbounds %struct.P3, ptr %3, i32 0, i32 2
+  %8 = load i64, ptr %7, align 8
+  %9 = trunc i64 %8 to i32
+  ret i32 %9
 }
 
-; Function Attrs: argmemonly nocallback nofree nounwind willreturn
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #1
-
 attributes #0 = { noinline nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+crc,+crypto,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+sha3,+sm4,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
-attributes #1 = { argmemonly nocallback nofree nounwind willreturn }
 
 !llvm.module.flags = !{!0, !1, !2, !3, !4}
 !llvm.ident = !{!5}

--- a/agg_c.ll
+++ b/agg_c.ll
@@ -1,0 +1,49 @@
+; ModuleID = 'agg.c'
+source_filename = "agg.c"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx14.0.0"
+
+%struct.P3 = type { i64, i64, i64 }
+
+; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
+define i64 @one(ptr noundef %0) #0 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  %3 = getelementptr inbounds %struct.P3, ptr %0, i32 0, i32 0
+  %4 = load i64, ptr %3, align 8
+  ret i64 %4
+}
+
+; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
+define i32 @main() #0 {
+  %1 = alloca i32, align 4
+  %2 = alloca %struct.P3, align 8
+  %3 = alloca %struct.P3, align 8
+  store i32 0, ptr %1, align 4
+  %4 = getelementptr inbounds %struct.P3, ptr %2, i32 0, i32 0
+  store i64 3, ptr %4, align 8
+  %5 = getelementptr inbounds %struct.P3, ptr %2, i32 0, i32 1
+  store i64 4, ptr %5, align 8
+  %6 = getelementptr inbounds %struct.P3, ptr %2, i32 0, i32 2
+  store i64 0, ptr %6, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %3, ptr align 8 %2, i64 24, i1 false)
+  %7 = call i64 @one(ptr noundef %3)
+  %8 = trunc i64 %7 to i32
+  ret i32 %8
+}
+
+; Function Attrs: argmemonly nocallback nofree nounwind willreturn
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #1
+
+attributes #0 = { noinline nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+crc,+crypto,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+sha3,+sm4,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+attributes #1 = { argmemonly nocallback nofree nounwind willreturn }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 2, !"SDK Version", [2 x i32] [i32 14, i32 4]}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{i32 7, !"frame-pointer", i32 1}
+!5 = !{!"Apple clang version 15.0.0 (clang-1500.3.9.4)"}

--- a/agg_fail.ll
+++ b/agg_fail.ll
@@ -10,35 +10,77 @@ target triple = "arm64-apple-macosx11.0.0"
 
 define i64 @main() !dbg !6 {
 entry:
-  %struct_literal = alloca { i64, i64, i64 }, align 8, !dbg !19
-  %x_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 0, !dbg !20
-  store i64 1, ptr %x_load, align 8, !dbg !20
-  %y_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 1, !dbg !21
-  store i64 2, ptr %y_load, align 8, !dbg !21
-  %z_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 2, !dbg !22
-  store i64 3, ptr %z_load, align 8, !dbg !22
-  %p1 = alloca ptr, align 8, !dbg !22
-  call void @llvm.dbg.declare(metadata ptr %p1, metadata !12, metadata !DIExpression()), !dbg !22
-  store ptr %struct_literal, ptr %p1, align 8, !dbg !22
-  %p1_loaded = load ptr, ptr %p1, align 8, !dbg !23
-  %0 = call i64 @one(ptr %p1_loaded), !dbg !24
-  ret i64 %0, !dbg !24
+  %struct_literal = alloca { i64, i64, i64 }, align 8, !dbg !22
+  %x_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 0, !dbg !23
+  store i64 1, ptr %x_load, align 8, !dbg !23
+  %y_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 1, !dbg !24
+  store i64 2, ptr %y_load, align 8, !dbg !24
+  %z_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 2, !dbg !25
+  store i64 3, ptr %z_load, align 8, !dbg !25
+  %p1 = alloca ptr, align 8, !dbg !25
+  call void @llvm.dbg.declare(metadata ptr %p1, metadata !12, metadata !DIExpression()), !dbg !25
+  store ptr %struct_literal, ptr %p1, align 8, !dbg !25
+  %p1_loaded = load ptr, ptr %p1, align 8, !dbg !26
+  %0 = call i64 @one(ptr %p1_loaded), !dbg !27
+  %o = alloca i64, align 8, !dbg !27
+  call void @llvm.dbg.declare(metadata ptr %o, metadata !19, metadata !DIExpression()), !dbg !27
+  store i64 %0, ptr %o, align 8, !dbg !27
+  %p1_loaded1 = load ptr, ptr %p1, align 8, !dbg !28
+  %1 = call i64 @two(ptr %p1_loaded1), !dbg !29
+  %t = alloca i64, align 8, !dbg !29
+  call void @llvm.dbg.declare(metadata ptr %t, metadata !20, metadata !DIExpression()), !dbg !29
+  store i64 %1, ptr %t, align 8, !dbg !29
+  %call_sret = alloca { i64, i64, i64 }, align 8, !dbg !30
+  call void @retStruct(ptr %call_sret), !dbg !30
+  %p3 = alloca { i64, i64, i64 }, align 8, !dbg !30
+  call void @llvm.dbg.declare(metadata ptr %p3, metadata !21, metadata !DIExpression()), !dbg !30
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %p3, ptr align 8 %call_sret, i64 24, i1 false), !dbg !30
+  %struc.y = getelementptr inbounds { i64, i64, i64 }, ptr %p3, i32 0, i32 1, !dbg !31
+  %struc.y2 = load i64, ptr %struc.y, align 8, !dbg !31
+  ret i64 %struc.y2, !dbg !31
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 
-define i64 @one({ i64, i64, i64 } %p) !dbg !25 {
+define i64 @one(ptr %p_arg) !dbg !32 {
 entry:
-  %p1 = alloca { i64, i64, i64 }, align 8, !dbg !30
-  call void @llvm.dbg.declare(metadata ptr %p1, metadata !29, metadata !DIExpression()), !dbg !30
-  store { i64, i64, i64 } %p, ptr %p1, align 8, !dbg !30
-  %struc.x = getelementptr inbounds { i64, i64, i64 }, ptr %p1, i32 0, i32 0, !dbg !31
-  %struc.x2 = load i64, ptr %struc.x, align 8, !dbg !31
-  ret i64 %struc.x2, !dbg !31
+  %p = alloca { i64, i64, i64 }, align 8, !dbg !37
+  call void @llvm.dbg.declare(metadata ptr %p, metadata !36, metadata !DIExpression()), !dbg !37
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %p, ptr align 8 %p_arg, i64 24, i1 false), !dbg !37
+  %struc.z = getelementptr inbounds { i64, i64, i64 }, ptr %p, i32 0, i32 2, !dbg !38
+  %struc.z1 = load i64, ptr %struc.z, align 8, !dbg !38
+  ret i64 %struc.z1, !dbg !38
+}
+
+; Function Attrs: argmemonly nocallback nofree nounwind willreturn
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #1
+
+define i64 @two(ptr %p_arg) !dbg !39 {
+entry:
+  %p = alloca ptr, align 8, !dbg !44
+  call void @llvm.dbg.declare(metadata ptr %p, metadata !43, metadata !DIExpression()), !dbg !44
+  store ptr %p_arg, ptr %p, align 8, !dbg !44
+  %p_loaded = load ptr, ptr %p, align 8, !dbg !45
+  %struc.z = getelementptr inbounds { i64, i64, i64 }, ptr %p_loaded, i32 0, i32 2, !dbg !45
+  %struc.z1 = load i64, ptr %struc.z, align 8, !dbg !45
+  ret i64 %struc.z1, !dbg !45
+}
+
+define void @retStruct(ptr sret({ i64, i64, i64 }) %0) !dbg !46 {
+entry:
+  %struct_literal = alloca { i64, i64, i64 }, align 8, !dbg !50
+  %x_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 0, !dbg !51
+  store i64 1, ptr %x_load, align 8, !dbg !51
+  %y_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 1, !dbg !52
+  store i64 2, ptr %y_load, align 8, !dbg !52
+  %z_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 2, !dbg !53
+  store i64 3, ptr %z_load, align 8, !dbg !53
+  ret ptr %struct_literal, !dbg !53
 }
 
 attributes #0 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+attributes #1 = { argmemonly nocallback nofree nounwind willreturn }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5}
@@ -49,29 +91,51 @@ attributes #0 = { nocallback nofree nosync nounwind readnone speculatable willre
 !3 = !{i32 2, !"Dwarf Version", i32 4}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"PIE Level", i32 2}
-!6 = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: !7, line: 40, type: !8, scopeLine: 40, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !11)
+!6 = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: !7, line: 58, type: !8, scopeLine: 58, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !11)
 !7 = !DIFile(filename: "agg.k1", directory: "/Users/knix/dev/k1")
 !8 = !DISubroutineType(types: !9)
 !9 = !{!10}
 !10 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_signed)
-!11 = !{!12}
-!12 = !DILocalVariable(name: "p1", scope: !6, file: !7, line: 42, type: !13, align: 64)
-!13 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "reference_897", baseType: !14, size: 64, align: 64, dwarfAddressSpace: 0)
+!11 = !{!12, !19, !20, !21}
+!12 = !DILocalVariable(name: "p1", scope: !6, file: !7, line: 60, type: !13, align: 64)
+!13 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "reference_634", baseType: !14, size: 64, align: 64, dwarfAddressSpace: 0)
 !14 = !DICompositeType(tag: DW_TAG_structure_type, name: "{x: i64, y: i64, z: i64}", scope: !6, file: !7, line: 35, size: 192, align: 64, elements: !15, identifier: "{x: i64, y: i64, z: i64}")
 !15 = !{!16, !17, !18}
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !6, file: !7, line: 35, baseType: !10, size: 64)
 !17 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !6, file: !7, line: 35, baseType: !10, size: 64, offset: 64)
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !6, file: !7, line: 35, baseType: !10, size: 64, offset: 128)
-!19 = !DILocation(line: 42, column: 14, scope: !6)
-!20 = !DILocation(line: 42, column: 17, scope: !6)
-!21 = !DILocation(line: 42, column: 23, scope: !6)
-!22 = !DILocation(line: 42, column: 29, scope: !6)
-!23 = !DILocation(line: 43, column: 6, scope: !6)
-!24 = !DILocation(line: 43, column: 2, scope: !6)
-!25 = distinct !DISubprogram(name: "one", linkageName: "one", scope: !6, file: !7, line: 36, type: !26, scopeLine: 36, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !28)
-!26 = !DISubroutineType(types: !27)
-!27 = !{!10, !14}
-!28 = !{!29}
-!29 = !DILocalVariable(name: "p", scope: !25, file: !7, line: 38, type: !14)
-!30 = !DILocation(line: 36, column: 7, scope: !25)
-!31 = !DILocation(line: 37, column: 2, scope: !25)
+!19 = !DILocalVariable(name: "o", scope: !6, file: !7, line: 61, type: !10, align: 64)
+!20 = !DILocalVariable(name: "t", scope: !6, file: !7, line: 62, type: !10, align: 64)
+!21 = !DILocalVariable(name: "p3", scope: !6, file: !7, line: 63, type: !14, align: 64)
+!22 = !DILocation(line: 60, column: 14, scope: !6)
+!23 = !DILocation(line: 60, column: 17, scope: !6)
+!24 = !DILocation(line: 60, column: 23, scope: !6)
+!25 = !DILocation(line: 60, column: 29, scope: !6)
+!26 = !DILocation(line: 61, column: 14, scope: !6)
+!27 = !DILocation(line: 61, column: 10, scope: !6)
+!28 = !DILocation(line: 62, column: 14, scope: !6)
+!29 = !DILocation(line: 62, column: 10, scope: !6)
+!30 = !DILocation(line: 63, column: 11, scope: !6)
+!31 = !DILocation(line: 64, column: 2, scope: !6)
+!32 = distinct !DISubprogram(name: "one", linkageName: "one", scope: !6, file: !7, line: 36, type: !33, scopeLine: 36, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!33 = !DISubroutineType(types: !34)
+!34 = !{!10, !14}
+!35 = !{!36}
+!36 = !DILocalVariable(name: "p", scope: !32, file: !7, line: 39, type: !14)
+!37 = !DILocation(line: 36, column: 7, scope: !32)
+!38 = !DILocation(line: 38, column: 2, scope: !32)
+!39 = distinct !DISubprogram(name: "two", linkageName: "two", scope: !6, file: !7, line: 40, type: !40, scopeLine: 40, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!10, !13}
+!42 = !{!43}
+!43 = !DILocalVariable(name: "p", scope: !39, file: !7, line: 43, type: !13)
+!44 = !DILocation(line: 40, column: 7, scope: !39)
+!45 = !DILocation(line: 42, column: 2, scope: !39)
+!46 = distinct !DISubprogram(name: "retStruct", linkageName: "retStruct", scope: !6, file: !7, line: 54, type: !47, scopeLine: 54, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !49)
+!47 = !DISubroutineType(types: !48)
+!48 = !{!14}
+!49 = !{}
+!50 = !DILocation(line: 55, column: 4, scope: !46)
+!51 = !DILocation(line: 55, column: 7, scope: !46)
+!52 = !DILocation(line: 55, column: 13, scope: !46)
+!53 = !DILocation(line: 55, column: 19, scope: !46)

--- a/agg_fail.ll
+++ b/agg_fail.ll
@@ -1,0 +1,77 @@
+; ModuleID = 'agg'
+source_filename = "builtin.k1"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx11.0.0"
+
+@SEEK_END = constant i32 2
+@SEEK_SET = constant i32 0
+@mb = constant i64 1048576
+@gb = constant i64 1073741824
+
+define i64 @main() !dbg !6 {
+entry:
+  %struct_literal = alloca { i64, i64, i64 }, align 8, !dbg !19
+  %x_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 0, !dbg !20
+  store i64 1, ptr %x_load, align 8, !dbg !20
+  %y_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 1, !dbg !21
+  store i64 2, ptr %y_load, align 8, !dbg !21
+  %z_load = getelementptr inbounds { i64, i64, i64 }, ptr %struct_literal, i32 0, i32 2, !dbg !22
+  store i64 3, ptr %z_load, align 8, !dbg !22
+  %p1 = alloca ptr, align 8, !dbg !22
+  call void @llvm.dbg.declare(metadata ptr %p1, metadata !12, metadata !DIExpression()), !dbg !22
+  store ptr %struct_literal, ptr %p1, align 8, !dbg !22
+  %p1_loaded = load ptr, ptr %p1, align 8, !dbg !23
+  %0 = call i64 @one(ptr %p1_loaded), !dbg !24
+  ret i64 %0, !dbg !24
+}
+
+; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+define i64 @one({ i64, i64, i64 } %p) !dbg !25 {
+entry:
+  %p1 = alloca { i64, i64, i64 }, align 8, !dbg !30
+  call void @llvm.dbg.declare(metadata ptr %p1, metadata !29, metadata !DIExpression()), !dbg !30
+  store { i64, i64, i64 } %p, ptr %p1, align 8, !dbg !30
+  %struc.x = getelementptr inbounds { i64, i64, i64 }, ptr %p1, i32 0, i32 0, !dbg !31
+  %struc.x2 = load i64, ptr %struc.x, align 8, !dbg !31
+  ret i64 %struc.x2, !dbg !31
+}
+
+attributes #0 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "k1_compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", sdk: "MacOSX.sdk")
+!1 = !DIFile(filename: "builtin.k1", directory: "/Users/knix/dev/k1/stdlib")
+!2 = !{i32 2, !"SDK Version", [2 x i32] [i32 14, i32 0]}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"PIE Level", i32 2}
+!6 = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: !7, line: 40, type: !8, scopeLine: 40, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !11)
+!7 = !DIFile(filename: "agg.k1", directory: "/Users/knix/dev/k1")
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10}
+!10 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_signed)
+!11 = !{!12}
+!12 = !DILocalVariable(name: "p1", scope: !6, file: !7, line: 42, type: !13, align: 64)
+!13 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "reference_897", baseType: !14, size: 64, align: 64, dwarfAddressSpace: 0)
+!14 = !DICompositeType(tag: DW_TAG_structure_type, name: "{x: i64, y: i64, z: i64}", scope: !6, file: !7, line: 35, size: 192, align: 64, elements: !15, identifier: "{x: i64, y: i64, z: i64}")
+!15 = !{!16, !17, !18}
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !6, file: !7, line: 35, baseType: !10, size: 64)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !6, file: !7, line: 35, baseType: !10, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !6, file: !7, line: 35, baseType: !10, size: 64, offset: 128)
+!19 = !DILocation(line: 42, column: 14, scope: !6)
+!20 = !DILocation(line: 42, column: 17, scope: !6)
+!21 = !DILocation(line: 42, column: 23, scope: !6)
+!22 = !DILocation(line: 42, column: 29, scope: !6)
+!23 = !DILocation(line: 43, column: 6, scope: !6)
+!24 = !DILocation(line: 43, column: 2, scope: !6)
+!25 = distinct !DISubprogram(name: "one", linkageName: "one", scope: !6, file: !7, line: 36, type: !26, scopeLine: 36, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !28)
+!26 = !DISubroutineType(types: !27)
+!27 = !{!10, !14}
+!28 = !{!29}
+!29 = !DILocalVariable(name: "p", scope: !25, file: !7, line: 38, type: !14)
+!30 = !DILocation(line: 36, column: 7, scope: !25)
+!31 = !DILocation(line: 37, column: 2, scope: !25)

--- a/src/k1/codegen_llvm.rs
+++ b/src/k1/codegen_llvm.rs
@@ -428,7 +428,6 @@ impl<'ctx> K1LlvmType<'ctx> {
 }
 
 struct BuiltinTypes<'ctx> {
-    ctx: &'ctx Context,
     int: IntType<'ctx>,
     unit: IntType<'ctx>,
     unit_value: IntValue<'ctx>,
@@ -637,7 +636,6 @@ impl<'ctx, 'module> Codegen<'ctx, 'module> {
 
         let ptr = ctx.i64_type().ptr_type(AddressSpace::default());
         let builtin_types = BuiltinTypes {
-            ctx,
             int: ctx.i64_type(),
             unit: ctx.i8_type(),
             unit_value: ctx.i8_type().const_int(0, false),

--- a/src/k1/typer.rs
+++ b/src/k1/typer.rs
@@ -1621,7 +1621,7 @@ pub struct TypedAbilityImpl {
     pub scope_id: ScopeId,
     pub span: SpanId,
     /// I need this so that I don't try to instantiate blanket implementations that fail
-    /// typechecking nocommit we can just skip the body
+    /// typechecking
     pub compile_errors: Vec<TyperError>,
 }
 
@@ -10038,6 +10038,10 @@ impl TypedModule {
             debug_assert!(buffer_generic.type_defn_info.scope == self.scopes.get_root_scope_id());
             debug_assert!(buffer_generic.type_defn_info.name == get_ident!(self, "Buffer"));
             debug_assert!(buffer_struct.fields.len() == 2);
+            debug_assert!(
+                buffer_struct.fields.iter().map(|f| self.name_of(f.name)).collect::<Vec<_>>()
+                    == vec!["len", BUFFER_DATA_FIELD_NAME]
+            );
         }
 
         // This just ensures our LIST_TYPE_ID constant is correct

--- a/src/k1/typer.rs
+++ b/src/k1/typer.rs
@@ -10607,6 +10607,10 @@ impl TypedModule {
         write_error(w, &self.ast.spans, &self.ast.sources, &error.message, error.level, error.span)
     }
 
+    pub fn write_location(&self, w: &mut impl std::io::Write, span: SpanId) -> std::io::Result<()> {
+        parse::write_error_location(w, &self.ast.spans, &self.ast.sources, span, ErrorLevel::Error)
+    }
+
     pub fn ice(&self, msg: impl AsRef<str>, error: Option<&TyperError>) -> ! {
         if let Some(error) = error {
             self.write_error(&mut std::io::stderr(), error).unwrap();

--- a/src/k1/typer/types.rs
+++ b/src/k1/typer/types.rs
@@ -110,6 +110,7 @@ pub const POINTER_TYPE_ID: TypeId = TypeId(12);
 pub const F32_TYPE_ID: TypeId = TypeId(13);
 pub const F64_TYPE_ID: TypeId = TypeId(14);
 
+pub const BUFFER_DATA_FIELD_NAME: &str = "data";
 pub const BUFFER_TYPE_ID: TypeId = TypeId(17);
 
 pub const LIST_TYPE_ID: TypeId = TypeId(21);
@@ -976,48 +977,6 @@ impl Types {
 
     pub fn type_count(&self) -> usize {
         self.types.len()
-    }
-
-    pub fn item_type_of_iterable(
-        &self,
-        identifiers: &Identifiers,
-        scopes: &Scopes,
-        type_id: TypeId,
-    ) -> Option<TypeId> {
-        match self.get(type_id) {
-            Type::Unit(_) => None,
-            Type::Char(_) => None,
-            Type::Integer(_) => None,
-            Type::Float(_) => None,
-            Type::Bool(_) => None,
-            Type::Pointer(_) => None,
-            // Check for List and string since they are currently structs
-            t @ Type::Struct(struc) => {
-                if let Some(list_type) = t.as_list_instance() {
-                    Some(list_type.element_type)
-                } else if let Some(defn_info) = struc.type_defn_info.as_ref() {
-                    if defn_info.name == identifiers.get("string").unwrap()
-                        && defn_info.scope == scopes.get_root_scope_id()
-                    {
-                        Some(CHAR_TYPE_ID)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            }
-            Type::Reference(_refer) => None,
-            Type::TypeVariable(_) => None,
-            Type::Enum(_) => None,
-            Type::EnumVariant(_) => None,
-            Type::Never(_) => None,
-            Type::Generic(_gen) => None,
-            Type::Function(_fun) => None,
-            Type::Closure(_closure) => None,
-            Type::ClosureObject(_co) => None,
-            Type::RecursiveReference(_) => None,
-        }
     }
 
     pub fn add_type_defn_mapping(

--- a/stdlib/buffer.k1
+++ b/stdlib/buffer.k1
@@ -199,9 +199,9 @@ ns BufferIterator {
 impl[T] Iterator[Item = T] for BufferIterator[T] {
   fn next(self: BufferIterator[T]*): Item? { 
     if self.pos < self.buf.len {
-      let ret = some(self.buf.get(self.pos));
+      let item = self.buf.get(self.pos);
       self.pos* <- self.pos + 1;
-      ret
+      some(item)
     } else .None
   }
   fn sizeHint(self: Self): { atLeast: u64, atMost: u64? } { 

--- a/stdlib/builtin.k1
+++ b/stdlib/builtin.k1
@@ -95,21 +95,6 @@ ability Iterable[impl Item, impl I: Iterator[Item = Item]] {
   fn iterator(self: Self): I
 }
 
-impl[S, F] Try[T = S, E = F] for Result[S, F] {
-  fn makeError(e: E): Self   { .Err(e) }
-  fn makeOk(t: T): Self { .Ok(t) }
-
-  fn isOk(self: Self): bool { self is .Ok(_) }
-  fn getOk(self: Self): T  { self.asOk().!.value }
-  fn getError(self: Self): E { self.asErr().!.value }
-}
-
-impl[S, F] Unwrap[Inner = S] for Result[S, F] {
-  fn hasValue(self: Self): bool { self is .Ok(_) }
-  fn unwrap(self: Self): Inner { self.getOk() }
-  fn make(inner: Inner): Self { Try/makeOk(inner) }
-}
-
 // inline fn unwrap_or[U, V: Unwrap[Inner = U]](v: V, backup: int): U {
 //   if v.hasValue() v.unwrap() else backup
 // }

--- a/stdlib/core.k1
+++ b/stdlib/core.k1
@@ -17,6 +17,11 @@ ns libc {
   extern(abort) fn abort(): never
 }
 
+fn assertEquals[T: Show](context locn: compiler/SourceLocation)(a: T, b: T): unit {
+  if a != b {
+    crash("ASSERT FAILED: \{a} != \{b}")
+  }
+}
 
 fn assert(context locn: compiler/SourceLocation)(value: bool): unit {
   if not value {
@@ -27,9 +32,9 @@ fn assert(context locn: compiler/SourceLocation)(value: bool): unit {
 fn crash(context locn: compiler/SourceLocation)(msg: string): never {
   let filename = locn.filename;
   let line = locn.line;
+  sys/printBacktrace();
   let s = "\{msg} at \{filename}:\{line}\n";
   eprint(s);
-  sys/printBacktrace();
   libc/abort()
 }
 

--- a/stdlib/core.k1
+++ b/stdlib/core.k1
@@ -276,3 +276,19 @@ impl Equals for i64 {
     self == other
   }
 }
+
+impl[S, F] Try[T = S, E = F] for Result[S, F] {
+  fn makeError(e: E): Self   { .Err(e) }
+  fn makeOk(t: T): Self { .Ok(t) }
+
+  fn isOk(self: Self): bool { self is .Ok(_) }
+  fn getOk(self: Self): T  { self.asOk().!.value }
+  fn getError(self: Self): E { self.asErr().!.value }
+}
+
+impl[S, F] Unwrap[Inner = S] for Result[S, F] {
+  fn hasValue(self: Self): bool { self is .Ok(_) }
+  fn unwrap(self: Self): Inner { self.getOk() }
+  fn make(inner: Inner): Self { Try/makeOk(inner) }
+}
+

--- a/stdlib/list.k1
+++ b/stdlib/list.k1
@@ -65,6 +65,8 @@ ns List {
     };
     let newBuffer = self.buffer._enlargedClone[T](newCap);
     self.buffer* <- newBuffer;
+    0;
+    ()
   }
 
   fn cloned[T](self: List[T]): List[T] {

--- a/test_src/closures.k1
+++ b/test_src/closures.k1
@@ -23,7 +23,7 @@ fn captures(): unit {
     addOne(x) + closedOver + addOne(closedOver) + (if closedOver == 3 1 else 0);
   };
 
-  assert(add(3) == 12);
+  assertEquals(add(3), 12);
 }
 
 fn captureMut(): unit {
@@ -52,10 +52,9 @@ fn main(): int {
   let addOne2 = addOne;
   let addOne3 = \(i: int) staticAddOne(i);
 
-  assert(addOne(1) == 2);
-  assert(addOne2(2) == 3);
-  assert(addOne3(3) == 4);
-
+  assertEquals(addOne(1), 2);
+  assertEquals(addOne2(2), 3);
+  assertEquals(addOne3(3), 4);
 
   let result = [1,2,3,5,6,7,8]
   | map(\(x: int) x + 1)

--- a/test_src/never_everywhere.k1
+++ b/test_src/never_everywhere.k1
@@ -9,10 +9,8 @@ fn whileCond(): never { while crash("asdf") { () } }
 fn enumConstrPayload(): never { Opt.Some(crash("asdf")) }
 fn getEnumPayload(): i64 { 
   let x: int? = Opt.Some(crash(""));
-  let y: int? = x;
-  y.!
 }
-fn castTarget(): i64 { crash("") as i64 }
+fn castTarget(): i64 { crash(""): i64 }
 fn inReturn(): never { 
   return(crash("what"))
 }

--- a/test_src/size_info.k1
+++ b/test_src/size_info.k1
@@ -1,0 +1,8 @@
+fn main(): int {
+  assert(sizeOf[string]() == 16);
+  assert(sizeOfStride[string]() == 16);
+  assert(alignOf[string]() == 8);
+  assert(sizeOf[{ x: u64, c: u8 }]() == 16);
+  assert(sizeOfStride[{ x: u64, c: u8 }]() == 16);
+  0
+}


### PR DESCRIPTION
We now talk about 2 types in LLVM for every K1 type:
- The "canonical repr type", which is how we physical represent the thing in places like a function parameter.
- The "rich value type", which talks about the actual shape of the data.
Aggregate types have a canonical repr type of `ptr`, but a rich value type of a StructType. So a struct _value_ in the IR is always a ptr, but we read to and write from it using the StructType we have from the type system.