### PR TITLE
Fix/parameter highlighting

### DIFF
--- a/src/bin/lsp_main.rs
+++ b/src/bin/lsp_main.rs
@@ -768,12 +768,44 @@ impl LanguageServer for Backend {
                 false => &k1.ast,
                 true => edited_sources.get(&file_url).unwrap(),
             };
+
+            let parameter_spans: HashSet<(u32, u32)> = if is_edited {
+                HashSet::new()
+            } else {
+                let entities = k1.ls_entities.borrow();
+
+                entities
+                    .get(&source.file_id)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|entity| match entity.kind {
+                        LsEntityKind::Variable { variable_id }
+                            if matches!(
+                                k1.variables.get(variable_id).kind,
+                                VariableKind::FnParam(_)
+                            ) =>
+                        {
+                            Some((entity.span.start, entity.span.len))
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            };
+
             // The goal is to use only 'atoms' to avoid overlaps and backwards movement
             let mut spans_and_kinds = vec![];
             for semantic_token in ast_for_file.semantic_tokens.iter() {
                 if semantic_token.span.file_id == source.file_id {
                     let token_type = match semantic_token.kind {
                         parse::SemanticTokenKind::Type => TokenTypes::Type,
+                        parse::SemanticTokenKind::Variable
+                            if parameter_spans.contains(&(
+                                semantic_token.span.start,
+                                semantic_token.span.len,
+                            )) =>
+                        {
+                            TokenTypes::Parameter
+                        }
                         parse::SemanticTokenKind::Variable => TokenTypes::Variable,
                         parse::SemanticTokenKind::String => TokenTypes::String,
                         parse::SemanticTokenKind::Keyword => TokenTypes::Keyword,

--- a/src/bin/lsp_main.rs
+++ b/src/bin/lsp_main.rs
@@ -780,6 +780,7 @@ impl LanguageServer for Backend {
                         parse::SemanticTokenKind::Function => TokenTypes::Function,
                         parse::SemanticTokenKind::Namespace => TokenTypes::Namespace,
                         parse::SemanticTokenKind::Operator => TokenTypes::Operator,
+                        parse::SemanticTokenKind::Parameter => TokenTypes::Parameter,
                     };
                     spans_and_kinds.push((semantic_token.span, token_type as u32, 0))
                 }

--- a/src/k1/parse.rs
+++ b/src/k1/parse.rs
@@ -1673,6 +1673,7 @@ pub(crate) type AstHandle<T> = Handle<T, ParsedProgram>;
 pub enum SemanticTokenKind {
     Type,
     Variable,
+    Parameter,
     String,
     Keyword,
     Function,
@@ -4649,6 +4650,7 @@ impl<'toks, 'module> Parser<'toks, 'module> {
 
     fn expect_fn_param(&mut self, is_context: bool) -> ParseResult<ParsedFnParam> {
         let (name_token, name) = self.expect_ident()?;
+        self.emit_semantic_token(name_token, SemanticTokenKind::Parameter);
         let type_expr = if self.maybe_consume(K::Colon).is_some() {
             let type_expr = self.expect_type_expression()?;
             ParsedFnParamType::Expr(type_expr)

--- a/src/k1/parse/parse_test.rs
+++ b/src/k1/parse/parse_test.rs
@@ -585,3 +585,22 @@ fn lex_error_does_not_poison_reused_token_buffer() {
         }
     }
 }
+
+#[test]
+fn function_parameters_emit_parameter_semantic_tokens() -> ParseResult<()> {
+    let ast = test_parse_input(
+        "parameter_semantic_tokens".to_string(),
+        "fn display(self: *person, label: string) {}",
+    )?;
+
+    let parameters: Vec<&str> = ast
+        .semantic_tokens
+        .iter()
+        .filter(|token| matches!(token.kind, SemanticTokenKind::Parameter))
+        .map(|token| ast.sources.get_span_content(&ast.mem, token.span))
+        .collect();
+
+    assert_eq!(parameters, vec!["self", "label"]);
+
+    Ok(())
+}


### PR DESCRIPTION
Add syntax highlighting for parameters

```
test parse::parse_test::function_parameters_emit_parameter_semantic_tokens ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 149 filtered out; finished in 0.00s
```