### PR TITLE
Add a platform hook for temp arena size

### DIFF
--- a/dogfood/freestanding_lib/consumer/consumer.c
+++ b/dogfood/freestanding_lib/consumer/consumer.c
@@ -65,6 +65,7 @@ int k1_platform_io_is_tty(int fd) {
   return 1;
 }
 void k1_platform_process_exit(int code) { sys_exit(code); }
+unsigned long k1_platform_tmp_arena_size(void) { return 64UL << 20; }
 
 int main(void) {
   long data[4] = {10, 20, 30, 40};

--- a/modules/core/mem.k1
+++ b/modules/core/mem.k1
@@ -84,7 +84,7 @@ ns mem {
 
   fn init-tmp-arena() {
     if not (arena-tmp is null) crash("arena-tmp already initialized")
-    arena-tmp = arena/init-fixed(1 * arena/gb)
+    arena-tmp = arena/init-fixed(platform/memory/tmp-arena-size())
   }
 
   fn tmp(): *arena {

--- a/modules/core/platform.k1
+++ b/modules/core/platform.k1
@@ -48,6 +48,14 @@ ns platform {
       r
     }
 
+    fn tmp-arena-size(): size {
+      if k1/is-static 1 * arena/gb
+      else #if k1/platform is {
+        :posix-macos or :posix-linux or :wasi -> 1 * arena/gb,
+        :bare -> port/bare/tmp-arena-size()
+      }
+    }
+
   }
 
   // heap delegates to whoever owns an allocator: libc on posix, the linking
@@ -920,6 +928,7 @@ ns platform {
       fn(extern("k1_platform_file_close")) close-fd(fd: i32)
       fn(extern("k1_platform_file_size")) file-size(fd: i32): i64
       fn(extern("k1_platform_process_exit")) exit(code: i32): never
+      fn(extern("k1_platform_tmp_arena_size")) tmp-arena-size(): size
       fn(extern("k1_platform_env_get")) getenv(name: ptr): ptr
       fn(extern("k1_platform_dylib_open")) dylib-open-c(path: ptr): ptr
       fn(extern("k1_platform_dylib_open_self")) dylib-open-self(): ptr


### PR DESCRIPTION
Use it for just `:bare`. It feels like I wanna just get to make my own arena / allocator but this was a quick fix